### PR TITLE
Desktop版とMobile版とを分けてPSIを取得・メトリックを投稿できるようにする

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,3 @@
 version = "3.5.3"
 runner.dialect = scala3
+trailingCommas = always

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.9")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.4")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")

--- a/src/main/scala/com/github/windymelt/psimackerel/CLIParameters.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/CLIParameters.scala
@@ -16,7 +16,7 @@ object CLIParameters:
       mackerelKey: Option[String],
       mackerelService: Option[String],
       targetUris: NonEmptyList[URI] | Path,
-      strategy: Option[Strategy]
+      strategy: Option[Strategy],
   )
 
   // Main object以外の場所でvalにすると壊れる!!のでここだけdefとしている
@@ -26,7 +26,7 @@ object CLIParameters:
       apiKeyForMackerel,
       mackerelServiceName,
       genericTargetUris,
-      strategy
+      strategy,
     )
       .mapN(Config.apply)
 
@@ -35,7 +35,7 @@ object CLIParameters:
       "psi-api-key",
       metavar = "API_KEY",
       help =
-        "Optional: Set PSI API key (can get yours at https://developers.google.com/speed/docs/insights/v5/get-started). API may return 429 Too Many Requests error unless you give no API key."
+        "Optional: Set PSI API key (can get yours at https://developers.google.com/speed/docs/insights/v5/get-started). API may return 429 Too Many Requests error unless you give no API key.",
     )
     .orNone
 
@@ -44,7 +44,7 @@ object CLIParameters:
       "mackerel-api-key",
       short = "k",
       metavar = "API_KEY",
-      help = "Set Mackerel API key."
+      help = "Set Mackerel API key.",
     )
     .orNone
 
@@ -53,7 +53,7 @@ object CLIParameters:
       "service",
       short = "s",
       metavar = "service_name",
-      help = "Set Mackerel service name."
+      help = "Set Mackerel service name.",
     )
     .orNone
 
@@ -64,15 +64,15 @@ object CLIParameters:
     .arguments[URI]("target uri")
     .validate(
       errorString(
-        "URI should contain scheme (HTTP / HTTPS). (Try prepending https://)"
-      )
+        "URI should contain scheme (HTTP / HTTPS). (Try prepending https://)",
+      ),
     )(nel => nel.forall(u => Seq("http", "https") contains (u.getScheme())))
 
   val targetUriFile = Opts.option[Path](
     "target-list",
     "Target URI list: one URI per line. Precedes by-argument URI list.",
     "f",
-    "target list file"
+    "target list file",
   )
 
   val strategy: Opts[Option[Strategy]] =
@@ -81,7 +81,7 @@ object CLIParameters:
         "strategy",
         "Strategy for request",
         "S",
-        "desktop/mobile"
+        "desktop/mobile",
       )
       .orNone
       .mapValidated {

--- a/src/main/scala/com/github/windymelt/psimackerel/CLIParameters.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/CLIParameters.scala
@@ -1,24 +1,33 @@
 package com.github.windymelt.psimackerel
 
+import cats.data.NonEmptyList
 import cats.implicits._
 import com.monovore.decline._
 import com.monovore.decline.effect._
-import java.net.URI
-import cats.data.NonEmptyList
-import java.nio.file.Path
 import fansi.Color
 
+import java.net.URI
+import java.nio.file.Path
+
 object CLIParameters:
-  case class Config(psiKey: Option[String], mackerelKey: Option[String], mackerelService: Option[String], targetUris: NonEmptyList[URI] | Path)
+  case class Config(
+      psiKey: Option[String],
+      mackerelKey: Option[String],
+      mackerelService: Option[String],
+      targetUris: NonEmptyList[URI] | Path
+  )
 
   // Main object以外の場所でvalにすると壊れる!!のでここだけdefとしている
-  def config = (apiKeyForPsi, apiKeyForMackerel, mackerelServiceName, genericTargetUris).mapN(Config.apply)
+  def config =
+    (apiKeyForPsi, apiKeyForMackerel, mackerelServiceName, genericTargetUris)
+      .mapN(Config.apply)
 
   val apiKeyForPsi = Opts
     .option[String](
       "psi-api-key",
       metavar = "API_KEY",
-      help = "Optional: Set PSI API key (can get yours at https://developers.google.com/speed/docs/insights/v5/get-started). API may return 429 Too Many Requests error unless you give no API key."
+      help =
+        "Optional: Set PSI API key (can get yours at https://developers.google.com/speed/docs/insights/v5/get-started). API may return 429 Too Many Requests error unless you give no API key."
     )
     .orNone
 
@@ -31,14 +40,31 @@ object CLIParameters:
     )
     .orNone
 
-  val mackerelServiceName = Opts.option[String]("service", short = "s", metavar = "service_name", help = "Set Mackerel service name.").orNone
+  val mackerelServiceName = Opts
+    .option[String](
+      "service",
+      short = "s",
+      metavar = "service_name",
+      help = "Set Mackerel service name."
+    )
+    .orNone
 
-  def genericTargetUris: Opts[NonEmptyList[URI] | Path] = targetUriFile orElse targetUris
+  def genericTargetUris: Opts[NonEmptyList[URI] | Path] =
+    targetUriFile orElse targetUris
 
-  val targetUris = Opts.arguments[URI]("target uri")
-    .validate(errorString("URI should contain scheme (HTTP / HTTPS). (Try prepending https://)"))
-      (nel => nel.forall(u => Seq("http", "https")contains(u.getScheme())))
+  val targetUris = Opts
+    .arguments[URI]("target uri")
+    .validate(
+      errorString(
+        "URI should contain scheme (HTTP / HTTPS). (Try prepending https://)"
+      )
+    )(nel => nel.forall(u => Seq("http", "https") contains (u.getScheme())))
 
-  val targetUriFile = Opts.option[Path]("target-list", "Target URI list: one URI per line. Precedes by-argument URI list.", "f", "target list file")
+  val targetUriFile = Opts.option[Path](
+    "target-list",
+    "Target URI list: one URI per line. Precedes by-argument URI list.",
+    "f",
+    "target list file"
+  )
 
-  private def errorString(s: String): String = fansi.Color.Red(s).toString
+private def errorString(s: String): String = fansi.Color.Red(s).toString

--- a/src/main/scala/com/github/windymelt/psimackerel/CLIParameters.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/CLIParameters.scala
@@ -14,12 +14,19 @@ object CLIParameters:
       psiKey: Option[String],
       mackerelKey: Option[String],
       mackerelService: Option[String],
-      targetUris: NonEmptyList[URI] | Path
+      targetUris: NonEmptyList[URI] | Path,
+      userAgent: Option[String]
   )
 
   // Main object以外の場所でvalにすると壊れる!!のでここだけdefとしている
   def config =
-    (apiKeyForPsi, apiKeyForMackerel, mackerelServiceName, genericTargetUris)
+    (
+      apiKeyForPsi,
+      apiKeyForMackerel,
+      mackerelServiceName,
+      genericTargetUris,
+      userAgent
+    )
       .mapN(Config.apply)
 
   val apiKeyForPsi = Opts
@@ -66,5 +73,10 @@ object CLIParameters:
     "f",
     "target list file"
   )
+
+  val userAgent =
+    Opts
+      .option[String]("user-agent", "User Agent for request", "A", "agent")
+      .orNone
 
 private def errorString(s: String): String = fansi.Color.Red(s).toString

--- a/src/main/scala/com/github/windymelt/psimackerel/Mackerel.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/Mackerel.scala
@@ -8,7 +8,7 @@ import io.circe.Encoder
 import io.circe.Json
 
 class MackerelClient(apiKey: String)(using
-    client: org.http4s.client.Client[IO]
+    client: org.http4s.client.Client[IO],
 ):
   import org.http4s._
   import org.http4s.Method.POST
@@ -25,9 +25,9 @@ class MackerelClient(apiKey: String)(using
     val req = POST(
       reqUri,
       `Content-Type`(jsonType),
-      Header("X-Api-Key", apiKey)
+      Header("X-Api-Key", apiKey),
     ).withEntity(
-      json
+      json,
     ) // Don't .toString(): it modifies Content-Type into text/plain
 
     client.expectOr[SuccessfulResponse](req) { res =>
@@ -38,23 +38,23 @@ class MackerelClient(apiKey: String)(using
     }(jsonOf[IO, SuccessfulResponse]) *> IO.unit
 
   def defineGraph(defs: Seq[GraphDefinition])(using
-      GraphDefinitionEncoder: Encoder[GraphDefinition]
+      GraphDefinitionEncoder: Encoder[GraphDefinition],
   ): IO[Unit] =
     import org.http4s.implicits.uri
     import io.circe.syntax._
     postReq(
       uri"https://api.mackerelio.com/api/v0/graph-defs/create",
-      defs.asJson
+      defs.asJson,
     )
 
   def postServiceMetrics(serviceName: String, metrics: Seq[ServiceMetric])(using
-      ServiceMetricsEncoder: Encoder[ServiceMetric]
+      ServiceMetricsEncoder: Encoder[ServiceMetric],
   ): IO[Unit] =
     import org.http4s.implicits.uri
     import io.circe.syntax._
     postReq(
       uri"https://api.mackerelio.com/api/v0/services/" / serviceName / "tsdb",
-      metrics.asJson
+      metrics.asJson,
     )
 
 object MackerelClient:
@@ -65,12 +65,12 @@ object MackerelClient:
       name: String,
       displayName: Option[String] = Some("Page Speed Insights score"),
       unit: Option[String],
-      metrics: Seq[Metric]
+      metrics: Seq[Metric],
   )
   case class Metric(
       name: String,
       displayName: Option[String],
-      isStacked: Boolean
+      isStacked: Boolean,
   )
   case class ServiceMetric(name: String, time: Instant, value: Double)
   case class SuccessfulResponse(success: true)

--- a/src/main/scala/com/github/windymelt/psimackerel/Mackerel.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/Mackerel.scala
@@ -1,11 +1,11 @@
 package com.github.windymelt.psimackerel
 
 import cats.effect.IO
-import io.circe.Codec
+import com.github.windymelt.psimackerel.MackerelClient.GraphDefinition
 import com.github.windymelt.psimackerel.MackerelClient.ServiceMetric
+import io.circe.Codec
 import io.circe.Encoder
 import io.circe.Json
-import com.github.windymelt.psimackerel.MackerelClient.GraphDefinition
 
 class MackerelClient(apiKey: String)(using
     client: org.http4s.client.Client[IO]
@@ -65,12 +65,12 @@ object MackerelClient:
       name: String,
       displayName: Option[String] = Some("Page Speed Insights score"),
       unit: Option[String],
-      metrics: Seq[Metric],
+      metrics: Seq[Metric]
   )
   case class Metric(
       name: String,
       displayName: Option[String],
-      isStacked: Boolean,
+      isStacked: Boolean
   )
   case class ServiceMetric(name: String, time: Instant, value: Double)
   case class SuccessfulResponse(success: true)

--- a/src/main/scala/com/github/windymelt/psimackerel/Main.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/Main.scala
@@ -18,7 +18,7 @@ object Main
     extends CommandIOApp(
       name = "psi-mackerel",
       header = "Post Google Page Speed Insights score to Mackerel",
-      version = "0.1.0"
+      version = "0.1.0",
     )
     with CurlApp:
 
@@ -33,15 +33,15 @@ object Main
         scores <- Util.backgroundIndicatorWithCount(
           "Fetching PSI score...",
           fetchedCount,
-          uris.size
+          uris.size,
         ) use { _ =>
           uris
             .map(uri =>
               (PSI().fetchPsiScore(
                 uri,
                 config.psiKey,
-                strategy = strategy
-              ) <* fetchedCount.update(_ + 1)).map(uri -> _)
+                strategy = strategy,
+              ) <* fetchedCount.update(_ + 1)).map(uri -> _),
             )
             .parSequence // but scala native doesn't support multithreading yet
         }
@@ -68,9 +68,9 @@ object Main
                           MackerelClient.ServiceMetric(
                             s"custom.pagespeed.$strategy-$safeUrl",
                             epoch,
-                            score * 100
-                          )
-                        )
+                            score * 100,
+                          ),
+                        ),
                       )
                     case (uri, None) => IO.unit // nop
                   }.parSequence
@@ -85,25 +85,25 @@ object Main
     }
 
   private def defineMackerelGraphDefinition(uris: NonEmptyList[Uri])(using
-      mc: MackerelClient
+      mc: MackerelClient,
   ): IO[Unit] =
     val metrics = uris.map { uri =>
       val safeUrl = uri.toString.replaceAll("""[^a-zA-Z0-9_\-]""", "-")
       MackerelClient.Metric(
         name = s"custom.pagespeed.$safeUrl",
         displayName = uri.toString.some,
-        isStacked = false
+        isStacked = false,
       )
     }.toList
     val graph = MackerelClient.GraphDefinition(
       name = "custom.pagespeed",
       unit = "percentage".some,
-      metrics = metrics
+      metrics = metrics,
     )
     mc.defineGraph(graph.pure[Seq])
 
   private def extractUris(
-      genericUris: NonEmptyList[java.net.URI] | java.nio.file.Path
+      genericUris: NonEmptyList[java.net.URI] | java.nio.file.Path,
   ): IO[NonEmptyList[Uri]] =
     import fs2.io.file.{Files, Path}
     import fs2.text

--- a/src/main/scala/com/github/windymelt/psimackerel/Main.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/Main.scala
@@ -1,14 +1,18 @@
 package com.github.windymelt.psimackerel
 
-import cats.effect.{IOApp, IO, ResourceIO, Resource, ExitCode}
+import cats.data.NonEmptyList
+import cats.effect.ExitCode
+import cats.effect.IO
+import cats.effect.IOApp
+import cats.effect.Resource
+import cats.effect.ResourceIO
 import cats.effect.std.Console
-import org.http4s.Uri
-import org.http4s.curl.CurlApp
-import org.http4s.client.Client
+import cats.implicits._
 import com.monovore.decline._
 import com.monovore.decline.effect._
-import cats.implicits._
-import cats.data.NonEmptyList
+import org.http4s.Uri
+import org.http4s.client.Client
+import org.http4s.curl.CurlApp
 
 object Main
     extends CommandIOApp(
@@ -21,12 +25,25 @@ object Main
   override def main: Opts[IO[ExitCode]] =
     CLIParameters.config map { config =>
       val epoch = java.time.Instant.now()
+      val strategy = config.strategy.getOrElse(Strategy.Desktop)
       given client: Client[IO] = curlClient
       for
         uris <- extractUris(config.targetUris)
         fetchedCount <- cats.effect.Ref.of[IO, Int](0)
-        scores <- Util.backgroundIndicatorWithCount("Fetching PSI score...", fetchedCount, uris.size) use { _ =>
-          uris.map(uri => (PSI().fetchPsiScore(uri, config.psiKey) <* fetchedCount.update(_ + 1)).map(uri -> _)).parSequence // but scala native doesn't support multithreading yet
+        scores <- Util.backgroundIndicatorWithCount(
+          "Fetching PSI score...",
+          fetchedCount,
+          uris.size
+        ) use { _ =>
+          uris
+            .map(uri =>
+              (PSI().fetchPsiScore(
+                uri,
+                config.psiKey,
+                strategy = strategy
+              ) <* fetchedCount.update(_ + 1)).map(uri -> _)
+            )
+            .parSequence // but scala native doesn't support multithreading yet
         }
         _ <- Console[IO].errorln("")
         _ <- Console[IO].errorln("All PSI scores are fetched")
@@ -38,28 +55,31 @@ object Main
             for
               _ <- Util
                 .backgroundIndicator("Defining Graph definition...")
-                .use { _ => defineMackerelGraphDefinition(uris)  }
+                .use { _ => defineMackerelGraphDefinition(uris) }
               _ <- Util.backgroundIndicator("Posting service metrics...").use {
                 _ =>
-                scores.map {
-                  case (uri, Some(score)) =>
-                    val safeUrl =
+                  scores.map {
+                    case (uri, Some(score)) =>
+                      val safeUrl =
                         uri.toString.replaceAll("""[^a-zA-Z0-9_\-]""", "-")
-                    mc.postServiceMetrics(
+                      mc.postServiceMetrics(
                         config.mackerelService.get,
                         Seq(
-                            MackerelClient.ServiceMetric(
-                                s"custom.pagespeed.$safeUrl",
-                                epoch,
-                                score * 100
-                            )
+                          MackerelClient.ServiceMetric(
+                            s"custom.pagespeed.$strategy-$safeUrl",
+                            epoch,
+                            score * 100
+                          )
                         )
-                  )
-                  case (uri, None) => IO.unit// nop
-                }.parSequence
+                      )
+                    case (uri, None) => IO.unit // nop
+                  }.parSequence
               }
             yield ()
-          case None => scores.map { s => IO.println(s"${s._2.map(_ * 100).getOrElse('?')}	${s._1}") }.sequence
+          case None =>
+            scores.map { s =>
+              IO.println(s"${s._2.map(_ * 100).getOrElse('?')}	${s._1}")
+            }.sequence
         _ <- Console[IO].errorln("")
       yield cats.effect.ExitCode(0)
     }
@@ -78,15 +98,23 @@ object Main
     val graph = MackerelClient.GraphDefinition(
       name = "custom.pagespeed",
       unit = "percentage".some,
-      metrics = metrics,
+      metrics = metrics
     )
     mc.defineGraph(graph.pure[Seq])
 
-  private def extractUris(genericUris: NonEmptyList[java.net.URI] | java.nio.file.Path): IO[NonEmptyList[Uri]] =
+  private def extractUris(
+      genericUris: NonEmptyList[java.net.URI] | java.nio.file.Path
+  ): IO[NonEmptyList[Uri]] =
     import fs2.io.file.{Files, Path}
     import fs2.text
     genericUris match
-      case nel: NonEmptyList[java.net.URI] => nel.map(uri => Uri.fromString(uri.toString).right.get).pure
+      case nel: NonEmptyList[java.net.URI] =>
+        nel.map(uri => Uri.fromString(uri.toString).right.get).pure
       case path: java.nio.file.Path =>
-        val lisIo = Files[IO].readUtf8Lines(Path.fromNioPath(path)).filterNot(_.isBlank).map{ s => Uri.fromString(s).right.get }.compile.toList
+        val lisIo = Files[IO]
+          .readUtf8Lines(Path.fromNioPath(path))
+          .filterNot(_.isBlank)
+          .map { s => Uri.fromString(s).right.get }
+          .compile
+          .toList
         lisIo.map(lis => NonEmptyList.fromList(lis).get) // TODO: avoid get

--- a/src/main/scala/com/github/windymelt/psimackerel/PSI.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/PSI.scala
@@ -18,9 +18,9 @@ class PSI():
   def fetchPsiScore(
       targetUri: org.http4s.Uri,
       apiKey: Option[String] = None,
-      strategy: Strategy = Strategy.Desktop
+      strategy: Strategy = Strategy.Desktop,
   )(using
-      client: org.http4s.client.Client[IO]
+      client: org.http4s.client.Client[IO],
   ): IO[Option[Double]] =
     import io.circe.syntax._
     import org.http4s.circe._

--- a/src/main/scala/com/github/windymelt/psimackerel/PSI.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/PSI.scala
@@ -15,16 +15,24 @@ class PSI():
     * @return
     *   Score [0, 1]
     */
-  def fetchPsiScore(targetUri: org.http4s.Uri, apiKey: Option[String] = None)(
-      using client: org.http4s.client.Client[IO]
+  def fetchPsiScore(
+      targetUri: org.http4s.Uri,
+      apiKey: Option[String] = None,
+      strategy: Strategy = Strategy.Desktop
+  )(using
+      client: org.http4s.client.Client[IO]
   ): IO[Option[Double]] =
     import io.circe.syntax._
     import org.http4s.circe._
     import cats.syntax.applicative.catsSyntaxApplicativeId
     import io.circe.Encoder.encodeString
+    val strategyString = strategy match
+      case Strategy.Desktop => "desktop"
+      case Strategy.Mobile  => "mobile"
+
     val url = apiKey match
       case Some(key) =>
-        s"https://www.googleapis.com/pagespeedonline/v5/runPagespeed?key=$key&url=$targetUri"
+        s"https://www.googleapis.com/pagespeedonline/v5/runPagespeed?key=$key&url=$targetUri&strategy=$strategyString"
       case None =>
         s"https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=$targetUri"
 

--- a/src/main/scala/com/github/windymelt/psimackerel/PSI.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/PSI.scala
@@ -3,6 +3,9 @@ package com.github.windymelt.psimackerel
 import cats.effect.IO
 import io.circe.Json
 
+enum Strategy:
+  case Desktop, Mobile
+
 class PSI():
   /** Fetches Page Speed Insight Score.
     *

--- a/src/main/scala/com/github/windymelt/psimackerel/Util.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/Util.scala
@@ -16,7 +16,7 @@ object Util:
   def backgroundIndicatorWithCount(
       msg: String,
       current: Ref[IO, Int],
-      all: Int
+      all: Int,
   ): ResourceIO[IO[OutcomeIO[Unit]]] =
     indicatorWithCount(msg, current, all).background
 
@@ -35,7 +35,7 @@ object Util:
   private def indicatorWithCount(
       m: String,
       current: Ref[IO, Int],
-      all: Int
+      all: Int,
   ): IO[Unit] = (
     for
       c <- current.get

--- a/src/main/scala/com/github/windymelt/psimackerel/Util.scala
+++ b/src/main/scala/com/github/windymelt/psimackerel/Util.scala
@@ -1,15 +1,23 @@
 package com.github.windymelt.psimackerel
 
-import cats.effect.{ResourceIO, IO, OutcomeIO, Ref}
+import cats.effect.IO
+import cats.effect.OutcomeIO
+import cats.effect.Ref
+import cats.effect.ResourceIO
 import cats.effect.std.Console
-import scala.concurrent.duration._
 import cats.syntax.applicative._
+
+import scala.concurrent.duration._
 import scala.language.postfixOps
 
 object Util:
   def backgroundIndicator(msg: String): ResourceIO[IO[OutcomeIO[Unit]]] =
     indicator(msg).background
-  def backgroundIndicatorWithCount(msg: String, current: Ref[IO, Int], all: Int): ResourceIO[IO[OutcomeIO[Unit]]] =
+  def backgroundIndicatorWithCount(
+      msg: String,
+      current: Ref[IO, Int],
+      all: Int
+  ): ResourceIO[IO[OutcomeIO[Unit]]] =
     indicatorWithCount(msg, current, all).background
 
   private def indicator(m: String): IO[Unit] = (
@@ -24,7 +32,11 @@ object Util:
     yield IO.sleep(1 second)
   ).foreverM
 
-  private def indicatorWithCount(m: String, current: Ref[IO, Int], all: Int): IO[Unit] = (
+  private def indicatorWithCount(
+      m: String,
+      current: Ref[IO, Int],
+      all: Int
+  ): IO[Unit] = (
     for
       c <- current.get
       _ <- Console[IO].error(s"\r| $m [$c / $all]")


### PR DESCRIPTION
## 背景

- 現行の実装ではDesktop版のスコアしか取得していない

## やったこと

- オプショナルなCLIオプションを追加して、`-S`によってStrategyを設定できるようにした
  - `desktop`(default) もしくは `mobile`を設定可能
- Mackerelのメトリックの形式を変更した
  - これまでは`custom.pagespeed.$safeUrl`というメトリックだったが、`custom.pagespeed.$strategy-$safeUrl`に整理した
- scalafmtをかけ直した
  - trailing commaを常に維持する設定にした(保存時にフォーマットがかかってしまったので、しょうがないからこのPRに交ぜる)
